### PR TITLE
Updates string resource locks for dotnet.exe and PackageManager Console project description

### DIFF
--- a/localize/comments/15/NuGet.CommandLine.XPlat.exe.lci
+++ b/localize/comments/15/NuGet.CommandLine.XPlat.exe.lci
@@ -337,7 +337,7 @@
       </Item>
       <Item ItemId=";Source_Description" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Specifies the server URL]]></Val>
+          <Val><![CDATA[Package source (URL, UNC/folder path or package source name) to use. Defaults to DefaultPushSource if specified in NuGet.Config.]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>
@@ -364,11 +364,11 @@
       </Item>
       <Item ItemId=";SymbolSource_Description" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org.]]></Val>
+          <Val><![CDATA[Symbol server URL to use.]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="URL", "nuget.smbsrc.net", "nuget.org"}]]></Cmt>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="URL"}]]></Cmt>
         </Cmts>
       </Item>
       <Item ItemId=";Symbols_Description" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
@@ -404,11 +404,11 @@
     <Disp Icon="Ver" Disp="true" LocTbl="false" Path=" \ ;Version \ 8 \ 0" />
     <Item ItemId=";Comments" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
       <Str Cat="Text">
-        <Val><![CDATA[NuGet wrapper for dotnet.exe.]]></Val>
+        <Val><![CDATA[NuGet executable wrapper for the dotnet CLI nuget functionality.]]></Val>
       </Str>
       <Disp Icon="Str" />
       <Cmts>
-        <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet", "dotnet.exe"}]]></Cmt>
+        <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
       </Cmts>
     </Item>
     <Item ItemId=";FileDescription" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">

--- a/localize/comments/15/NuGetConsole.Host.PowerShell.dll.lci
+++ b/localize/comments/15/NuGetConsole.Host.PowerShell.dll.lci
@@ -1,16 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="C:\BuildAgent\work\c21523a748a3d719\NuGet\bin\Release\NuGetTools\15\NuGetConsole.Host.PowerShell.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\10\s\artifacts\NuGetConsole.Host.PowerShell\15.0\bin\release\NuGetConsole.Host.PowerShell.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="LcxAdmin" />
   </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
   <Item ItemId=";Managed Resources" ItemType="0" PsrId="211" Leaf="true">
     <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
   </Item>
   <Item ItemId=";NuGet.CommonResources.resources" ItemType="0" PsrId="211" Leaf="false">
-    <Disp Icon="Str" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
     <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
-      <Disp Icon="Str" LocTbl="false" />
-      <Item ItemId=";EnsureImportedMessage" ItemType="0" PsrId="211" Leaf="true">
+      <Disp Icon="Str" Disp="true" LocTbl="false" />
+      <Item ItemId=";EnsureImportedMessage" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.]]></Val>
         </Str>
@@ -22,9 +23,9 @@
     </Item>
   </Item>
   <Item ItemId=";NuGetConsole.Host.PowerShell.Resources.resources" ItemType="0" PsrId="211" Leaf="false">
-    <Disp Icon="Str" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
     <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
-      <Disp Icon="Str" LocTbl="false" />
+      <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId=";Add_WrapperMembers" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[#]D;]A;# This private script adds $InterfaceType members to $psObject which invokes on $wrappedObject]D;]A;#]D;]A;Param(]D;]A;    $psObject,]D;]A;    $wrappedObject,]D;]A;    [Type]5D;$InterfaceType]D;]A;)]D;]A;]D;]A;function GetInvoker]D;]A;{]D;]A;    Param(]D;]A;        $Target,]D;]A;        $Method]D;]A;    )]D;]A;]D;]A;    if ($Method.IsGenericMethodDefinition) {]D;]A;        return {]D;]A;            $t = $Target]D;]A;            $m = $Method.MakeGenericMethod($args)]D;]A;            ]D;]A;            if (!$m.GetParameters()) {]D;]A;                return $m.Invoke($t, @())]D;]A;            }]D;]A;            ]D;]A;            $o = New-Object PSObject]D;]A;            Add-Member -InputObject $o -MemberType ScriptMethod -Name Invoke -Value {]D;]A;                    [NuGetConsole.Host.PowerShell.Implementation.PSTypeWrapper]5D;::InvokeMethod($t, $m, $args)]D;]A;                }.GetNewClosure()]D;]A;            return $o]D;]A;        }.GetNewClosure()]D;]A;    }]D;]A;    ]D;]A;    return {]D;]A;        [NuGetConsole.Host.PowerShell.Implementation.PSTypeWrapper]5D;::InvokeMethod($Target, $Method, $args)]D;]A;    }.GetNewClosure()]D;]A;}]D;]A;]D;]A;$InterfaceType.GetMembers() | %{]D;]A;    $m = $_]D;]A;    $getter = $null]D;]A;    $setter = $null]D;]A;    ]D;]A;    if ($m.MemberType -eq [System.Reflection.MemberTypes]5D;"Property") {]D;]A;    ]D;]A;        if ($m.CanRead) {]D;]A;            $getter = GetInvoker $wrappedObject $m.GetGetMethod()]D;]A;        }]D;]A;        if ($m.CanWrite) {]D;]A;            $setter = GetInvoker $wrappedObject $m.GetSetMethod()]D;]A;        }]D;]A;        ]D;]A;        $prop = New-Object Management.Automation.PSScriptProperty $m.Name, $getter, $setter]D;]A;        $psObject.PSObject.Properties.Add($prop)]D;]A;        ]D;]A;    } elseif (!$m.IsSpecialName -and]D;]A;            ($m.MemberType -eq [System.Reflection.MemberTypes]5D;"Method")) {]D;]A;    ]D;]A;        $invoker = GetInvoker $wrappedObject $m]D;]A;        $method = New-Object Management.Automation.PSScriptMethod $m.Name, $invoker]D;]A;        $psObject.PSObject.Methods.Add($method)]D;]A;    }]D;]A;}]D;]A;]]></Val>
@@ -34,7 +35,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";Console_DisclaimerText" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";Console_DisclaimerText" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Each package is licensed to you by its owner. NuGet is not responsible for, nor does it grant any licenses to, third-party packages. Some packages may include dependencies which are governed by additional licenses. Follow the package source (feed) URL to determine any dependencies.]]></Val>
         </Str>
@@ -76,11 +77,11 @@
     <Disp Icon="Ver" Disp="true" LocTbl="false" Path=" \ ;Version \ 8 \ 0" />
     <Item ItemId=";Comments" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
       <Str Cat="Text">
-        <Val><![CDATA[PowerConsole PowerShell host implementation]]></Val>
+        <Val><![CDATA[Package Manager Console PowerShell host implementation]]></Val>
       </Str>
       <Disp Icon="Str" />
       <Cmts>
-        <Cmt Name="LcxAdmin"><![CDATA[{Locked="PowerConsole", "PowerShell"}]]></Cmt>
+        <Cmt Name="LcxAdmin"><![CDATA[{Locked="PowerShell"}]]></Cmt>
       </Cmts>
     </Item>
     <Item ItemId=";CompanyName" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1093421/
Details:
- Ran lcxadmin.exe (included in this repository) to update the string locks reported in the bug.

A string lock helps translators to know which parts in a string resource don't need localization. Those string parts and are written as-is in the final, translated string resource.