### PR TITLE
Changes confirmation prompt for Russian language in PMC and CLI clients

### DIFF
--- a/localize/RUS/15/NuGet.Client.VisualStudio.PowerShell.resources.dll.lcl
+++ b/localize/RUS/15/NuGet.Client.VisualStudio.PowerShell.resources.dll.lcl
@@ -294,7 +294,7 @@
         <Str Cat="Text">
           <Val><![CDATA[No to Al&l]]></Val>
           <Tgt Cat="Text" Stat="Loc" Appr="PreApproved" Orig="New" AutoAppr="N/A">
-            <Val><![CDATA[Нет для &всех]]></Val>
+            <Val><![CDATA[Нет для в&сех]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/localize/RUS/15/NuGet.Cmdlets.resources.dll.lcl
+++ b/localize/RUS/15/NuGet.Cmdlets.resources.dll.lcl
@@ -298,7 +298,7 @@
         <Str Cat="Text">
           <Val><![CDATA[No to Al&l]]></Val>
           <Tgt Cat="Text" Stat="Loc" Appr="PreApproved" Orig="New" AutoAppr="N/A">
-            <Val><![CDATA[Нет для &всех]]></Val>
+            <Val><![CDATA[Нет для в&сех]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/localize/RUS/15/NuGet.PackageManagement.PowerShellCmdlets.dll.lcl
+++ b/localize/RUS/15/NuGet.PackageManagement.PowerShellCmdlets.dll.lcl
@@ -269,7 +269,7 @@
         <Str Cat="Text">
           <Val><![CDATA[No to Al&l]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Нет для &всех]]></Val>
+            <Val><![CDATA[Нет для в&сех]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/localize/comments/15/NuGet.Client.VisualStudio.PowerShell.resources.dll.lci
+++ b/localize/comments/15/NuGet.Client.VisualStudio.PowerShell.resources.dll.lci
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="C:\BuildAgent\work\fea8ec2fb9b8541c\NuGet\bin\Release\NuGetTools\14\NuGet.Client.VisualStudio.PowerShell.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+  <Item ItemId=";Managed Resources" ItemType="0" PsrId="211" Leaf="true">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
+    <Modified By="SamV" DateTime="2014-12-23T15:27:59Z" />
+  </Item>
+  <Item ItemId=";NuGet.Client.VisualStudio.PowerShell.Resources.resources" ItemType="0" PsrId="211" Leaf="false">
+    <Disp Icon="Str" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
+    <Modified By="SamV" DateTime="2014-12-23T15:27:59Z" />
+    <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
+      <Disp Icon="Str" LocTbl="false" />
+      <Modified By="SamV" DateTime="2014-12-23T15:27:59Z" />
+      <Item ItemId=";Cmdlet_CommandObsolete" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[The {0} Command has been deprecated. Type 'get-help NuGet' to see all available NuGet commands.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2015-01-05T15:20:20Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="get-help NuGet", "NuGet"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_FailToParseVersion" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Fail to parse the input of Version parameter: {0} to a valid Semantic version. ]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2015-01-05T15:20:20Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="Version"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_FileExistsNoClobber" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Output file '{0}' exists and -NoClobber was specified.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2015-01-05T15:20:20Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="-NoClobber"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_InvalidPSDrive" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[The PSDrive '{0}' was not found.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2015-01-05T15:20:20Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="PSDrive"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_InvalidProjectManagerInstance" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[The specified IProjectManager instance is not recognized.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2015-01-05T15:20:20Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="IProjectManager"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_InvalidProvider" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Only paths residing on a FileSystemProvider are supported.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2015-01-05T15:20:20Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="FileSystemProvider"}]]></Cmt>
+        </Cmts>
+      </Item>
+    </Item>
+  </Item>
+</LCX>

--- a/localize/comments/15/NuGet.Cmdlets.resources.dll.lci
+++ b/localize/comments/15/NuGet.Cmdlets.resources.dll.lci
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="D:\dd\WebStackRuntime\Main\ReferenceAssemblies\NuGet\NuGet.Cmdlets.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+  <Item ItemId=";Managed Resources" ItemType="0" PsrId="211" Leaf="true">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
+    <Modified By="LucianoAP" DateTime="2012-02-22T15:35:42Z" />
+  </Item>
+  <Item ItemId=";NuGet.PowerShell.Commands.Resources.resources" ItemType="0" PsrId="211" Leaf="false">
+    <Disp Icon="Str" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
+    <Modified By="LucianoAP" DateTime="2012-02-22T15:35:42Z" />
+    <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
+      <Disp Icon="Str" LocTbl="false" />
+      <Modified By="LucianoAP" DateTime="2012-02-22T15:35:42Z" />
+      <Item ItemId=";Cmdlet_FileExistsNoClobber" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Output file '{0}' exists and -NoClobber was specified.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="federicomu" DateTime="2012-02-22T17:42:40Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="-NoClobber"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_InvalidPSDrive" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[The PSDrive '{0}' was not found.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="federicomu" DateTime="2012-02-22T17:42:40Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="PSDrive"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_InvalidProjectManagerInstance" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[The specified IProjectManager instance is not recognized.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="a_konev" DateTime="2012-03-02T10:38:25Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="IProjectManager"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_InvalidProvider" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Only paths residing on a FileSystemProvider are supported.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="federicomu" DateTime="2012-02-22T17:42:40Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="FileSystemProvider"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_LocalCacheFailure" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[The source at {0} is unreachable. There is no NuGet Local Cache found]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2013-12-31T10:27:50Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_NuspecFileNotFound" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Unable to locate a .nuspec file in the specified project.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="federicomu" DateTime="2012-02-22T17:42:40Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked=".nuspec"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_TooManySpecFiles" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[More than one .nuspec files were found.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="federicomu" DateTime="2012-02-22T17:42:40Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked=".nuspec"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_UrlMissing" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[The package '{0}' does not provide the requested URL.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="a_konev" DateTime="2012-03-02T10:38:25Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="URL"}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId=";Cmdlet_WhatIfReinstallUnsupported" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Specifying both -Reinstall and -WhatIf is not supported for now.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Modified By="SamV" DateTime="2013-12-31T10:27:50Z" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="-Reinstall", "-WhatIf"}]]></Cmt>
+        </Cmts>
+      </Item>
+    </Item>
+  </Item>
+  <Item ItemId=";Version" ItemType="0" PsrId="211" Leaf="false">
+    <Disp Icon="Ver" Disp="true" LocTbl="false" Path=" \ ;Version \ 8 \ 0" />
+    <Modified By="LucianoAP" DateTime="2012-02-22T15:35:42Z" />
+    <Item ItemId=";Comments" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+      <Str Cat="Text">
+        <Val><![CDATA[This assembly contains NuGet PowerShell cmdlets.]]></Val>
+      </Str>
+      <Disp Icon="Str" />
+      <Modified By="federicomu" DateTime="2012-02-22T17:42:40Z" />
+      <Cmts>
+        <Cmt Name="LcxAdmin"><![CDATA[{Placeholder="NuGet PowerShell"} Product names]]></Cmt>
+      </Cmts>
+    </Item>
+  </Item>
+  <Item ItemId=";Version" ItemType="8" PsrId="211" Leaf="true">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
+    <Modified By="LucianoAP" DateTime="2012-02-22T15:35:42Z" />
+  </Item>
+</LCX>

--- a/localize/comments/15/NuGet.PackageManagement.PowerShellCmdlets.dll.lci
+++ b/localize/comments/15/NuGet.PackageManagement.PowerShellCmdlets.dll.lci
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="C:\BuildAgent\work\c21523a748a3d719\NuGet\bin\Release\NuGetTools\15\NuGet.PackageManagement.PowerShellCmdlets.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\10\s\artifacts\NuGet.PackageManagement.PowerShellCmdlets\15.0\bin\release\NuGet.PackageManagement.PowerShellCmdlets.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="LcxAdmin" />
   </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
   <Item ItemId=";Managed Resources" ItemType="0" PsrId="211" Leaf="true">
     <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
   </Item>
   <Item ItemId=";NuGet.PackageManagement.PowerShellCmdlets.Resources.resources" ItemType="0" PsrId="211" Leaf="false">
-    <Disp Icon="Str" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
     <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
-      <Disp Icon="Str" LocTbl="false" />
+      <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId=";Cmdlet_CommandRemoved" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[The {0} Command has been deprecated and will be removed in the next release. Please modify your PowerShell scripts accordingly. ]]></Val>
@@ -37,7 +38,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="FileSystemProvider"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";Cmdlet_Log_OperationWhatIf" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";Cmdlet_Log_OperationWhatIf" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[WhatIf: {0}]]></Val>
         </Str>
@@ -46,7 +47,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="WhatIf"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";Cmdlet_MissingPackages" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";Cmdlet_MissingPackages" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Some NuGet packages are missing from the solution. The packages need to be restored in order to build the dependency graph. Restore the packages before performing any operations.]]></Val>
         </Str>
@@ -55,7 +56,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";Cmdlet_RequestRestartToCompleteUninstall" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";Cmdlet_RequestRestartToCompleteUninstall" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[One or more packages could not be completely uninstalled: '{0}'. Restart Visual Studio to finish uninstall.]]></Val>
         </Str>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/7789

Based on powershell command 
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.1#example-2--stop-a-specific-instance-of-a-process

The hotkey is moved to the second letter of the second word.

Add description on files.

Test Added: No

Validation: Manual validation with the following steps:

1. Create a .NET Framework ASP.NET WebForms project
2. Modify `Scripts\bootstrap.js` file
3. If bootstrap.js is not installed, install it via PMC using `install-package bootstrap`
4. Modify `Scripts\bootstrap.js` file, add a comment
5. Run `update-packages -reinstall` in PMC
4. The following message appears:
![image](https://user-images.githubusercontent.com/1192347/112381215-91e40900-8ca7-11eb-8518-8a74764fea1d.png)

