### PR TITLE
Adds missing .lci files from Localize Assemblies step in NuGet.Client CI

### DIFF
--- a/localize/comments/15/Microsoft.Build.NuGetSdkResolver.dll.lci
+++ b/localize/comments/15/Microsoft.Build.NuGetSdkResolver.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\28\s\artifacts\Microsoft.Build.NuGetSdkResolver\15.0\bin\release\net46\Microsoft.Build.NuGetSdkResolver.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.Build.Tasks.Console.dll.lci
+++ b/localize/comments/15/NuGet.Build.Tasks.Console.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\597\s\artifacts\NuGet.Build.Tasks.Console\16.0\bin\release\netcoreapp2.1\NuGet.Build.Tasks.Console.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.Indexing.dll.lci
+++ b/localize/comments/15/NuGet.Indexing.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\10\s\artifacts\NuGet.Indexing\15.0\bin\release\net45\NuGet.Indexing.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.LibraryModel.dll.lci
+++ b/localize/comments/15/NuGet.LibraryModel.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\10\s\artifacts\NuGet.LibraryModel\15.0\bin\release\net45\NuGet.LibraryModel.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.Localization.dll.lci
+++ b/localize/comments/15/NuGet.Localization.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\22\s\artifacts\NuGet.Localization\15.0\bin\release\netstandard1.3\NuGet.Localization.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.SolutionRestoreManager.Interop.dll.lci
+++ b/localize/comments/15/NuGet.SolutionRestoreManager.Interop.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\10\s\artifacts\NuGet.SolutionRestoreManager.Interop\15.0\bin\release\net46\NuGet.SolutionRestoreManager.Interop.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.VisualStudio.Contracts.dll.lci
+++ b/localize/comments/15/NuGet.VisualStudio.Contracts.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="C:\A\_work\9\s\artifacts\NuGet.VisualStudio.Contracts\16.0\bin\release\netstandard2.0\NuGet.VisualStudio.Contracts.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.VisualStudio.Internal.Contracts.dll.lci
+++ b/localize/comments/15/NuGet.VisualStudio.Internal.Contracts.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\667\s\artifacts\NuGet.VisualStudio.Internal.Contracts\16.0\bin\release\netstandard2.0\NuGet.VisualStudio.Internal.Contracts.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.VisualStudio.Interop.dll.lci
+++ b/localize/comments/15/NuGet.VisualStudio.Interop.dll.lci
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\10\s\artifacts\NuGet.VisualStudio.Interop\15.0\bin\release\net46\NuGet.VisualStudio.Interop.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+</LCX>

--- a/localize/comments/15/NuGet.VisualStudio.OnlineEnvironment.Client.dll.lci
+++ b/localize/comments/15/NuGet.VisualStudio.OnlineEnvironment.Client.dll.lci
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="E:\A\_work\633\s\artifacts\NuGet.VisualStudio.OnlineEnvironment.Client\16.0\bin\release\NuGet.VisualStudio.OnlineEnvironment.Client.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+  <Item ItemId=";Managed Resources" ItemType="0" PsrId="211" Leaf="true">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
+  </Item>
+  <Item ItemId=";NuGet.VisualStudio.OnlineEnvironment.Client.Resources.resources" ItemType="0" PsrId="211" Leaf="false">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
+    <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
+      <Disp Icon="Str" Disp="true" LocTbl="false" />
+      <Item ItemId=";Finished" ItemType="0" PsrId="211" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[========== Finished ==========]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="=========="}]]></Cmt>
+        </Cmts>
+      </Item>
+    </Item>
+  </Item>
+</LCX>

--- a/localize/comments/15/NuGetConsole.Host.PowerShellProvider.resources.dll.lci
+++ b/localize/comments/15/NuGetConsole.Host.PowerShellProvider.resources.dll.lci
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="D:\DD\Dev10\OffCycle\AspNet\Plan9\Main\ReferenceAssemblies\NuGet\NuGetConsole.Host.PowerShellProvider.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+  </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
+  <Item ItemId=";Managed Resources" ItemType="0" PsrId="211" Leaf="true">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
+  </Item>
+  <Item ItemId=";NuGetConsole.Host.PowerShellProvider.Resources.resources" ItemType="0" PsrId="211" Leaf="false">
+    <Disp Icon="Str" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
+    <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
+      <Disp Icon="Str" LocTbl="false" />
+      <Item ItemId=";Host_PSNotInstalled" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Error: The Package Manager Console requires PowerShell 2.0 runtime, which is not detected on this machine. Please install the PowerShell 2.0 from http://support.microsoft.com/kb/968929 and restart Visual Studio.]]></Val>
+        </Str>
+        <Disp Icon="Str" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked="http://support.microsoft.com/kb/968929"}]]></Cmt>
+        </Cmts>
+        <Notes>
+          <Note Name="Loc" Order="0"><![CDATA[FP LocVer.  Reported in 51907 ]]></Note>
+        </Notes>
+      </Item>
+    </Item>
+  </Item>
+</LCX>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/904

Adds .lci files generated with lcxadmin.exe from a .lcl file in CHS folder.

This PR should remove the warnings listed in 'Localize Assemblies' step in NuGet.Client CI. See warning samples [here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4667924&view=logs&j=2ea8c801-c4c3-578e-0ff0-bcf4c12d9404&t=c22e513a-85a0-5260-f82a-6e75295f43fd&l=1194)

.lci files contains comments for translators that helps in localization process. For example, a comment can be used to indicate string parts that must not be localized.
