### PR TITLE
Locks `MoreInfoUrl` string resource to avoid pseudo-localization

### DIFF
--- a/localize/comments/15/extension.vsixlangpack.lci
+++ b/localize/comments/15/extension.vsixlangpack.lci
@@ -1,27 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="C:\dd2\NuGetVisualStudio\Main\ReferenceAssemblies\NuGet\extension.vsixlangpack" PsrId="210" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+<LCX SchemaVersion="6.0" Name="C:\BuildAgent\work\fea8ec2fb9b8541c\NuGet\ReferenceAssemblies\NuGet\extension.vsixlangpack" PsrId="210" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="LcxAdmin" />
   </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
   <Item ItemId=";&lt;License&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
-    <Item ItemId="0;d8e09482fdf359b5e23408bd7eb9a302" ItemType="42;XML:Text" PsrId="210" Leaf="true">
-      <Str Cat="AppData">
+    <Item ItemId="0;d8e09482fdf359b5e23408bd7eb9a302" ItemType="42;XML:Text" PsrId="210" InstFlg="true" Leaf="true">
+      <Str Cat="AppData" UsrLk="true">
         <Val><![CDATA[EULA.rtf]]></Val>
       </Str>
-      <Disp Icon="Str" Order="5" />
+      <Disp Icon="Str" />
       <Cmts>
         <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
       </Cmts>
+      <Notes>
+        <Note Name="Loc" Order="0"><![CDATA[Leave in English by deisgn]]></Note>
+      </Notes>
     </Item>
   </Item>
   <Item ItemId=";&lt;LocalizedDescription&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
-    <Item ItemId="0;3545d4cb7ecc0bce0cb55061d67cfaa6" ItemType="42;XML:Text" PsrId="210" Leaf="true">
+    <Item ItemId="0;3545d4cb7ecc0bce0cb55061d67cfaa6" ItemType="42;XML:Text" PsrId="210" InstFlg="true" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[A collection of tools to automate the process of installing, upgrading, configuring, and removing packages from a VS Project.]]></Val>
       </Str>
-      <Disp Icon="Str" Order="3" />
+      <Disp Icon="Str" />
       <Cmts>
         <Cmt Name="LcxAdmin"><![CDATA[{Locked="VS"}]]></Cmt>
       </Cmts>
@@ -29,13 +33,25 @@
   </Item>
   <Item ItemId=";&lt;LocalizedName&gt;" ItemType="0" PsrId="210" Leaf="false">
     <Disp Icon="Str" Disp="true" LocTbl="false" />
-    <Item ItemId="0;44ccc32ef2fb12f9386c44174e6be5e2" ItemType="42;XML:Text" PsrId="210" Leaf="true">
+    <Item ItemId="0;44ccc32ef2fb12f9386c44174e6be5e2" ItemType="42;XML:Text" PsrId="210" InstFlg="true" Leaf="true">
       <Str Cat="AppData">
         <Val><![CDATA[NuGet Package Manager]]></Val>
       </Str>
-      <Disp Icon="Str" Order="1" />
+      <Disp Icon="Str" />
       <Cmts>
         <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
+      </Cmts>
+    </Item>
+  </Item>
+  <Item ItemId=";&lt;MoreInfoUrl&gt;" ItemType="0" PsrId="210" Leaf="false">
+    <Disp Icon="Str" Disp="true" LocTbl="false" />
+    <Item ItemId="0;4d223fa949e3124dfd8db6a5f678e60d" ItemType="42;XML:Text" PsrId="210" Leaf="true">
+      <Str Cat="AppData" UsrLk="true">
+        <Val><![CDATA[https://github.com/NuGet/NuGet.Client]]></Val>
+      </Str>
+      <Disp Icon="Str" />
+      <Cmts>
+        <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
       </Cmts>
     </Item>
   </Item>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/961

### Description 

Locks MoreInfoURI in extension.vsixlangpack to avoid pseudo-localizing the MoreInfoUri.

This URL is validated at runtime in VS.

Pseudo-localization adds random characters at the begining and at the end of the string. 

Without this fix, `MoreInfoUri` field in extension.vsixlangpack is pseudo-localized and then, it introduces random chars in the URL. This makes runtime VSIX validaiton fail.

#### Without string lock (before) in pseudo-localization

```xml
<?xml version="1.0" encoding="utf-8"?>
<VsixLanguagePack Version="1.0.0" xmlns=http://schemas.microsoft.com/developer/vsx-schema-lp/2010>
  <LocalizedName>!ALKDA!NuGet Package Manager ßţĐ!</LocalizedName>
  <LocalizedDescription>!i322Y!A collection of tools to automate the process of installing, upgrading, configuring, and removing packages from a VS Project. ßţĐšŻľŞąŁ ßţĐ!</LocalizedDescription>
  <License>EULA.rtf</License>
  <MoreInfoUrl>!2Nwep!https://github.com/NuGet/NuGet.Client ßţĐšŻ!</MoreInfoUrl>
</VsixLanguagePack>
```

#### With string lock (after) in pseudo-localization

```xml
<?xml version="1.0" encoding="utf-8"?>
<VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
  <LocalizedName>!ALKDA!NuGet Package Manager ýÛö!</LocalizedName>
  <LocalizedDescription>!i322Y!A collection of tools to automate the process of installing, upgrading, configuring, and removing packages from a VS Project. ýÛöÑéÎåÀŠ ýÛö!</LocalizedDescription>
  <License>EULA.rtf</License>
  <MoreInfoUrl>https://github.com/NuGet/NuGet.Client</MoreInfoUrl>
</VsixLanguagePack>
```

The scring is locked in .lci comments file using lcxadmin.exe tool.

### Validation

Manual Test run

![image](https://user-images.githubusercontent.com/1192347/133158577-b1d0bfbb-f51b-4e98-848a-bb6ba7ef4f99.png)
