### PR TITLE
Locks strings to resolve them from localization report

### DIFF
--- a/localize/comments/15/NuGet.MSSigning.Extensions.dll.lci
+++ b/localize/comments/15/NuGet.MSSigning.Extensions.dll.lci
@@ -11,7 +11,7 @@
     <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
     <Item ItemId=";Strings" ItemType="0" PsrId="211" Leaf="false">
       <Disp Icon="Str" Disp="true" LocTbl="false" />
-      <Item ItemId=";MSSignCommandInvalidArgumentException" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";MSSignCommandInvalidArgumentException" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Invalid value provided for '{0}'. For a list of accepted values, please visit https://docs.nuget.org/docs/reference/command-line-reference]]></Val>
         </Str>
@@ -20,7 +20,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="https://docs.nuget.org/docs/reference/command-line-reference"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";MSSignCommandNoPackageException" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";MSSignCommandNoPackageException" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference]]></Val>
         </Str>
@@ -29,7 +29,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="https://docs.nuget.org/docs/reference/command-line-reference"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";MSSignCommandUsageDescription" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";MSSignCommandUsageDescription" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Signs a NuGet package.]]></Val>
         </Str>
@@ -38,40 +38,40 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";MSSignCommandUsageExamples" ItemType="0" PsrId="211" Leaf="true">
-        <Str Cat="Text">
+      <Item ItemId=";MSSignCommandUsageExamples" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text" UsrLk="true">
           <Val><![CDATA[nuget mssign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName "Cryptographic Service Provider"  -KeyContainer "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a" -CertificateFingerprint "4003d786cc374004bfdfc4f3e8ef9b3a"  ]D;]A;]D;]A;nuget mssign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName "Cryptographic Service Provider"  -KeyContainer "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a" -CertificateFingerprint "4003d786cc374004bfdfc4f3e8ef9b3a" -OutputDirectory .\..\Signed]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="nuget mssign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName \"Cryptographic Service Provider\"  -KeyContainer \"4003d786-cc37-4004-bfdf-c4f3e8ef9b3a\" -CertificateFingerprint \"4003d786cc374004bfdfc4f3e8ef9b3a\" -OutputDirectory .\..\Signed"}]]></Cmt>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";MSSignCommandUsageSummary" ItemType="0" PsrId="211" Leaf="true">
-        <Str Cat="Text">
+      <Item ItemId=";MSSignCommandUsageSummary" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text" UsrLk="true">
           <Val><![CDATA[<package_path> -Timestamper <timestamp_server_url> -CertificateFile <p7b_file_path> -CSPName <cryptographic_service _provider_name>  -KeyContainer <key_container_guid>  -CertificateFingerprint <certificate_fingerprint>]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="<package_path> -Timestamper <timestamp_server_url> -CertificateFile <p7b_file_path> -CSPName <cryptographic_service _provider_name>  -KeyContainer <key_container_guid>  -CertificateFingerprint <certificate_fingerprint>"}]]></Cmt>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";RepoSignCommandUsageExamples" ItemType="0" PsrId="211" Leaf="true">
-        <Str Cat="Text">
+      <Item ItemId=";RepoSignCommandUsageExamples" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text" UsrLk="true">
           <Val><![CDATA[nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName "Cryptographic Service Provider" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -V3ServiceIndexUrl https://v3.index.test]D;]A;]D;]A;nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName "Cryptographic Service Provider" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -OutputDirectory .\..\Signed -PackageOwners "owner1;owner2" -V3ServiceIndexUrl https://v3.index.test]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName \"Cryptographic Service Provider\" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -V3ServiceIndexUrl https://v3.index.test"} {Locked="nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName \"Cryptographic Service Provider\" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -OutputDirectory .\..\Signed -PackageOwners \"owner1;owner2\" -V3ServiceIndexUrl https://v3.index.test"}]]></Cmt>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";RepoSignCommandUsageSummary" ItemType="0" PsrId="211" Leaf="true">
-        <Str Cat="Text">
+      <Item ItemId=";RepoSignCommandUsageSummary" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Text" UsrLk="true">
           <Val><![CDATA[<package_path> -Timestamper <timestamp_server_url> -CertificateFile <p7b_file_path> -CSPName <cryptographic_service_provider_name> -KeyContainer <key_container_guid> -CertificateFingerprint <certificate_fingerprint> -PackageOwners <package_owners> -V3ServiceIndexUrl <v3_service_index_url>]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="<package_path> -Timestamper <timestamp_server_url> -CertificateFile <p7b_file_path> -CSPName <cryptographic_service_provider_name> -KeyContainer <key_container_guid> -CertificateFingerprint <certificate_fingerprint> -PackageOwners <package_owners> -V3ServiceIndexUrl <v3_service_index_url>"}]]></Cmt>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
         </Cmts>
       </Item>
     </Item>

--- a/localize/comments/15/NuGet.PackageManagement.UI.dll.lci
+++ b/localize/comments/15/NuGet.PackageManagement.UI.dll.lci
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<LCX SchemaVersion="6.0" Name="E:\A\_work\93\s\artifacts\NuGet.PackageManagement.UI\15.0\bin\release\NuGet.PackageManagement.UI.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+<LCX SchemaVersion="6.0" Name="E:\A\_work\10\s\artifacts\NuGet.PackageManagement.UI\15.0\bin\release\NuGet.PackageManagement.UI.dll" PsrId="211" FileType="1" SrcCul="en-US" Desc="Commenting file created by LCXAdmin. For more information, please visit http://localizability/longhorn/LcxAdmin.asp" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
   <OwnedComments>
     <Cmt Name="LcxAdmin" />
   </OwnedComments>
+  <Settings Name="@vsLocTools@\default.lss" Type="Lss" />
   <Item ItemId=";Managed Resources" ItemType="0" PsrId="211" Leaf="true">
     <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
   </Item>
@@ -10,8 +11,8 @@
     <Disp Icon="Dlg" Expand="true" Disp="true" LocTbl="false" Path=" \ ;Managed Resources \ 0 \ 0" />
     <Item ItemId=";GeneralOptionControl" ItemType="4" PsrId="211" Leaf="false">
       <Disp Edtr="External" Icon="Dlg" Disp="true" LocTbl="false" />
-      <Item ItemId=";defaultPackageManagementFormatItems.Items" ItemType="0" PsrId="211" Leaf="true">
-        <Str Cat="Combo Box">
+      <Item ItemId=";defaultPackageManagementFormatItems.Items" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
+        <Str Cat="Combo Box" UsrLk="true">
           <Val><![CDATA[Packages.config]]></Val>
         </Str>
         <Disp Icon="Dlg" />
@@ -19,7 +20,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="Packages.config"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";defaultPackageManagementFormatItems.Items1" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";defaultPackageManagementFormatItems.Items1" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Combo Box">
           <Val><![CDATA[PackageReference]]></Val>
         </Str>
@@ -28,16 +29,16 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="PackageReference"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";localsCommandButton.Text" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";localsCommandButton.Text" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Button">
-          <Val><![CDATA[Clear All NuGet Cache(s)]]></Val>
+          <Val><![CDATA[&Clear All NuGet Storage]]></Val>
         </Str>
         <Disp Icon="Dlg" />
         <Cmts>
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";packageRestoreAutomaticCheckBox.Text" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";packageRestoreAutomaticCheckBox.Text" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Check Box">
           <Val><![CDATA[Auto&matically check for missing packages during build in Visual Studio]]></Val>
         </Str>
@@ -46,7 +47,7 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="Visual Studio"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";packageRestoreConsentCheckBox.Text" ItemType="0" PsrId="211" Leaf="true">
+      <Item ItemId=";packageRestoreConsentCheckBox.Text" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Check Box">
           <Val><![CDATA[&Allow NuGet to download missing packages]]></Val>
         </Str>
@@ -106,42 +107,6 @@
           <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
         </Cmts>
       </Item>
-      <Item ItemId=";PackageRestoreCompleted" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Finished configuring this solution to restore NuGet packages on build.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-        <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
-        </Cmts>
-      </Item>
-      <Item ItemId=";PackageRestoreConfirmation" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Do you want to configure this solution to download and restore missing NuGet packages during build? A .nuget folder will be added to the root of the solution that contains files that enable package restore.]D;]A;]D;]A;Packages installed into Website projects will not be restored during build. Consider converting those into Web application projects if necessary.]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-        <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet", ".nuget"}]]></Cmt>
-        </Cmts>
-      </Item>
-      <Item ItemId=";PackageRestoreErrorMessage" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[An error occurred while configuring the solution to restore NuGet packages on build]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-        <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
-        </Cmts>
-      </Item>
-      <Item ItemId=";PackageRestoreWaitMessage" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
-        <Str Cat="Text">
-          <Val><![CDATA[Configuring the solution to restore NuGet packages on build...]]></Val>
-        </Str>
-        <Disp Icon="Str" />
-        <Cmts>
-          <Cmt Name="LcxAdmin"><![CDATA[{Locked="NuGet"}]]></Cmt>
-        </Cmts>
-      </Item>
       <Item ItemId=";RadioBtn_PackageRef" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[PackageReference in project file]]></Val>
@@ -152,7 +117,7 @@
         </Cmts>
       </Item>
       <Item ItemId=";RadioBtn_PackagesConfig" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
-        <Str Cat="Text">
+        <Str Cat="Text" UsrLk="true">
           <Val><![CDATA[Packages.config]]></Val>
         </Str>
         <Disp Icon="Str" />
@@ -216,7 +181,7 @@
       </Item>
       <Item ItemId=";Warning_ProjectJson" ItemType="0" PsrId="211" InstFlg="true" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[These options are not applicable to projects managing their dependencies through project.json.]]></Val>
+          <Val><![CDATA[These options are not applicable to projects managing their dependencies through project.json or PackageReference]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>


### PR DESCRIPTION
Fixes https://github.com/NuGet/Client.Engineering/issues/1862

Details:
- Locks example strings in NuGet.MSSigning.Extensions; those strings does not need localization
- Updates comments in NuGet.PackageManagement.UI